### PR TITLE
Allow Symfony 7.x usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "type": "library",
     "require": {
         "php": ">=8.1",
-        "symfony/dom-crawler": "^3.0|^4.0|^5.0|^6.0",
+        "symfony/dom-crawler": "^3.0|^4.0|^5.0|^6.0|^7.0",
         "guzzlehttp/guzzle": "^6.1|^7.1",
-        "symfony/css-selector": "^3.0|^4.0|^5.0|^6.0"
+        "symfony/css-selector": "^3.0|^4.0|^5.0|^6.0|^7.0"
     },
     "require-dev": {
         "pestphp/pest": "^2.19",


### PR DESCRIPTION
Symfony 7.0 has been recently released.

This PR allow using your library with the new framework version.