### PR TITLE
Fix error when parsing page without locale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 vendor/
 .php-cs-fixer.cache
+composer.lock

--- a/src/Traits/CanExtractBySelector.php
+++ b/src/Traits/CanExtractBySelector.php
@@ -23,6 +23,6 @@ trait CanExtractBySelector
             }
         }
 
-        return count($data) ? $data[0] : "";
+        return $data[0] ?? "";
     }
 }

--- a/tests/Unit/Extractors/LocaleExtractorTest.php
+++ b/tests/Unit/Extractors/LocaleExtractorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use GuzzleHttp\Psr7\Response;
+
+use function PHPUnit\Framework\assertEquals;
+
+test('it parses locale', function () {
+    $parser = $this->createSiteParserWithMockFakeHttpClient([
+        new Response(body: '<!DOCTYPE html><html lang="en"><head></head><body></body></html>')
+    ]);
+
+    $link = $parser->parse('https://hazaveh.net');
+
+    assertEquals("en", $link->locale);
+});
+
+test('it handle page without locale', function () {
+    $parser = $this->createSiteParserWithMockFakeHttpClient([
+        new Response(body: '<!DOCTYPE html><html><head></head><body></body></html>')
+    ]);
+
+    $link = $parser->parse('https://hazaveh.net');
+
+    assertEquals("", $link->locale);
+});


### PR DESCRIPTION
When using the lib, I've an error on parsing website doesn't have the `lang` attribute.

```text
PHP Fatal error:  Uncaught TypeError: Hazaveh\LinkPreview\Extractors\LocaleExtractor::extractSelectors(): Return value must be of type string, null returned in /home/jdecool/Workspace/external/php-link-preview/src/Traits/CanExtractBySelector.php:26
Stack trace:
#0 /home/jdecool/Workspace/external/php-link-preview/src/Extractors/LocaleExtractor.php(22): Hazaveh\LinkPreview\Extractors\LocaleExtractor::extractSelectors(Object(Symfony\Component\DomCrawler\Crawler))
#1 /home/jdecool/Workspace/external/php-link-preview/src/Parsers/SiteParser.php(86): Hazaveh\LinkPreview\Extractors\LocaleExtractor::extract(Object(Symfony\Component\DomCrawler\Crawler))
#2 /home/jdecool/Workspace/external/php-link-preview/src/Parsers/SiteParser.php(42): Hazaveh\LinkPreview\Parsers\SiteParser->extractTags('<!doctype html>...')
#3 /home/jdecool/Workspace/external/php-link-preview/src/Client.php(25): Hazaveh\LinkPreview\Parsers\SiteParser->parse('https://jdecool...')
#4 /home/jdecool/Workspace/external/php-link-preview/run.php(6): Hazaveh\LinkPreview\Client->parse('https://jdecool...')
#5 {main}
  thrown in /home/jdecool/Workspace/external/php-link-preview/src/Traits/CanExtractBySelector.php on line 26
```

So, I've fixed the `CanExtractBySelector` and add a unit test to ensure my update solved the problem.